### PR TITLE
design: 탭뷰에서 서치 버튼 따르 빼기

### DIFF
--- a/APEX/APEX/Presentation/Root/RootView.swift
+++ b/APEX/APEX/Presentation/Root/RootView.swift
@@ -17,24 +17,18 @@ struct RootView: View {
     
     var body: some View {
         TabView(selection: $selection) {
-            ContactsView()
-                .tabItem {
-                    Label("Contacts", systemImage: "person.3.fill")
-                }
-                .tag(Tabs.contacts)
+            
+            Tab("Contacts", systemImage: "person.3.fill", value: Tabs.contacts) {
+                ContactsView()
+            }
 
-            NotesView()
-                .tabItem {
-                    Label("Notes", systemImage: "note.text")
-                }
-                .tag(Tabs.notes)
+            Tab("Notes", systemImage: "note.text", value: Tabs.notes) {
+                NotesView()
+            }
 
-            // Fallback search tab for iOS 17-style API
-            Text("")
-                .tabItem {
-                    Label("Search", systemImage: "magnifyingglass")
-                }
-                .tag(Tabs.search)
+            Tab("Search", systemImage: "magnifyingglass", value: Tabs.search, role: .search) {
+                Text("")
+            }
         }
     }
 }


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
탭뷰에서 검색버튼을 따로 뺐습니다.

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/8f1c111f-68ac-4625-b6dc-c3011e58d83b" />


## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
