### PR TITLE
[Feature#157] 음성 메모 아래에 stt 나오도록 구현

### DIFF
--- a/APEX/APEX/Presentation/Chatting/ChattingViewModel.swift
+++ b/APEX/APEX/Presentation/Chatting/ChattingViewModel.swift
@@ -8,6 +8,7 @@ import Foundation
 import Combine
 import SwiftUI
 import AVFoundation
+import Speech
 
 @MainActor
 final class ChattingViewModel: ViewModelable {
@@ -205,6 +206,10 @@ private extension ChattingViewModel {
         notes.append(noteWithProgress)
         ChatStore.shared.setNotes(notes, for: clientId)
         if let idx = notes.indices.last { startUploadsForNote(at: idx) }
+        // Kick off STT for audio notes so that STT appears under the tile in chat
+        if let idx = notes.indices.last {
+            transcribeIfAudio(at: idx)
+        }
     }
     
     func startUploadsForNote(at index: Int) {
@@ -362,6 +367,50 @@ private extension ChattingViewModel {
     func kickOffPendingUploadsIfNeeded() {
         for idx in notes.indices where hasPendingProgress(at: idx) {
             startUploadsForNote(at: idx)
+        }
+    }
+    
+    // MARK: - STT for audio notes
+    func transcribeIfAudio(at index: Int) {
+        guard notes.indices.contains(index) else { return }
+        guard case let .audio(audios) = notes[index].bundle, let first = audios.first else { return }
+        let url = first.url
+        // Avoid duplicate work if text already exists
+        if let existing = notes[index].text, !existing.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return }
+        
+        SFSpeechRecognizer.requestAuthorization { [weak self] status in
+            guard let self else { return }
+            guard status == .authorized else { return }
+            
+            let ko = Locale(identifier: "ko-KR")
+            let preferredLocale = SFSpeechRecognizer.supportedLocales().contains(ko) ? ko : Locale.current
+            guard let recognizer = SFSpeechRecognizer(locale: preferredLocale), recognizer.isAvailable else { return }
+            
+            let request = SFSpeechURLRecognitionRequest(url: url)
+            request.shouldReportPartialResults = true
+            request.taskHint = .dictation
+            if #available(iOS 13.0, *) {
+                request.requiresOnDeviceRecognition = false
+            }
+            var hints: [String] = []
+            let base = url.deletingPathExtension().lastPathComponent
+            if !base.isEmpty { hints.append(base) }
+            request.contextualStrings = hints
+            
+            recognizer.recognitionTask(with: request) { [weak self] result, error in
+                guard let self else { return }
+                if let result = result {
+                    DispatchQueue.main.async {
+                        if self.notes.indices.contains(index) {
+                            self.notes[index].text = result.bestTranscription.formattedString
+                            ChatStore.shared.setNotes(self.notes, for: self.clientId)
+                        }
+                    }
+                }
+                if let _ = error {
+                    // Silently ignore errors in chat auto-STT
+                }
+            }
         }
     }
     

--- a/APEX/APEX/Presentation/Chatting/SubView/ChatMessageView.swift
+++ b/APEX/APEX/Presentation/Chatting/SubView/ChatMessageView.swift
@@ -187,10 +187,49 @@ struct ChatMessageView: View {
                             }
                             .tint(.red)
                         }
+                    
+                    // Filename + STT text under the audio tile
+                    VStack(alignment: .leading, spacing: 4) {
+                        let baseName = first.url.deletingPathExtension().lastPathComponent
+                        let displayName = baseName.isEmpty ? "음성 메모" : baseName
+                        if let attr = highlightedText(displayName, query: highlightQuery) {
+                            Text(attr)
+                                .font(.caption2)
+                                .foregroundStyle(Color("BlackLabel"))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        } else {
+                            Text(displayName)
+                            .font(.caption2)
+                            .foregroundStyle(Color("BlackLabel"))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        }
+                        if let stt = note.text, !stt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            if let attr = highlightedText(stt, query: highlightQuery) {
+                                Text(attr)
+                                    .font(.body6)
+                                    .foregroundStyle(Color("BlackLabel"))
+                            } else {
+                                Text(stt)
+                                    .font(.body6)
+                                    .foregroundStyle(Color("BlackLabel"))
+                            }
+                        }
+                    }
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.vertical, 12)
+                    .padding(.horizontal, 8)
+                    .background(Color("BackgroundSecondary"))
+                    .clipShape(RoundedRectangle(cornerRadius: 15, style: .continuous))
                 }
             }
             
             if let text = note.text {
+                // For audio notes, STT is rendered directly under the audio tile above.
+                if case .audio = note.bundle {
+                    EmptyView()
+                } else {
                 VStack(alignment: .trailing, spacing: 8) {
                     SelectableText(
                         text,
@@ -231,6 +270,7 @@ struct ChatMessageView: View {
                     }
                     .tint(.red)
                 }
+                }
             }
         }
         .alert("\(deleteSubjectText) 삭제하겠습니까?", isPresented: $showDeleteAlert) {
@@ -241,6 +281,25 @@ struct ChatMessageView: View {
 }
 
 extension ChatMessageView {
+    // Highlight helper for filename/STT to match global search behavior
+    func highlightedText(_ text: String, query: String?) -> AttributedString? {
+        guard let q = query?.trimmingCharacters(in: .whitespacesAndNewlines), !q.isEmpty else { return nil }
+        let mas = NSMutableAttributedString(string: text)
+        let ns = text as NSString
+        let fullRange = NSRange(location: 0, length: ns.length)
+        let options: NSString.CompareOptions = [.caseInsensitive, .diacriticInsensitive]
+        var searchRange = fullRange
+        while true {
+            let found = ns.range(of: q, options: options, range: searchRange)
+            if found.location == NSNotFound { break }
+            mas.addAttribute(.backgroundColor, value: UIColor.systemYellow.withAlphaComponent(0.45), range: found)
+            let nextLoc = found.location + found.length
+            if nextLoc >= ns.length { break }
+            searchRange = NSRange(location: nextLoc, length: ns.length - nextLoc)
+        }
+        return AttributedString(mas)
+    }
+    
     func tempURLForImageData(_ data: Data) -> URL? {
         let isPNG: Bool = data.prefix(8) == Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
         let ext = isPNG ? "png" : "jpg"


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #이슈번호

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 음성 메모 아래에 stt 나오도록 구현

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15, iOS 17.4 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- `XxxViewModel.swift` 파일의 로직 분리 구조
- `NetworkManager.swift`의 공통 로직 처리 방식