### PR TITLE
[design#163] 채팅아카이브뷰 디자인 미세 수정

### DIFF
--- a/APEX/APEX/Presentation/ChattingArchive/ChattingArchiveView.swift
+++ b/APEX/APEX/Presentation/ChattingArchive/ChattingArchiveView.swift
@@ -195,7 +195,7 @@ struct ChattingArchiveView: View {
     }
 
     private var sharedLinksSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 0) {
             sectionHeader(title: "링크", iconName: "URL", iconColor: Color(hex: "BC0D59"), action: {
                 viewModel.send(.presentArchive(.links))
             })
@@ -251,7 +251,7 @@ struct ChattingArchiveView: View {
     }
 
     private var sharedAudioSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 0) {
             sectionHeader(title: "음성메모", iconName: "Waveform", iconColor: Color(hex: "E28822"), action: {
                 viewModel.send(.presentArchive(.audio))
             })
@@ -330,6 +330,7 @@ struct ChattingArchiveView: View {
                     .foregroundColor(Color("BlackLabel"))
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 15)
+                    .frame(height: 48)
             }
             .buttonStyle(.plain)
             .background(Color("BackgroundSecondary"))
@@ -344,15 +345,16 @@ struct ChattingArchiveView: View {
                 Button(role: .destructive) {
                     viewModel.send(.showDeleteContactOverlay(true))
                 } label: {
-                    HStack {
+                    HStack(spacing: 4) {
                         Image(systemName: "trash.fill")
                             .font(.system(size: 16, weight: .bold))
                         Text("연락처 삭제하기")
+                            .font(.body5)
                     }
-                    .font(.body5)
                     .foregroundColor(Color("Error"))
                     .frame(maxWidth: .infinity)
-                    .padding(.vertical, 15)
+                    .padding(.vertical, 12)
+                    .frame(height: 48)
                 }
                 .buttonStyle(.plain)
                 .background(Color("ErrorContainer"))
@@ -392,6 +394,7 @@ struct ChattingArchiveView: View {
             }
             .padding(.vertical, 10)
         }
+        .padding(.leading, 8)
         .padding(.trailing, 16)
         .buttonStyle(SectionHeaderPressedStyle())
     }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #이슈번호

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 채팅아카이브뷰 디자인 미세 수정

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15, iOS 17.4 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- `XxxViewModel.swift` 파일의 로직 분리 구조
- `NetworkManager.swift`의 공통 로직 처리 방식