### PR TITLE
[Bug#184] 클라우드킷 안정화 & 공유확장 뷰 mvvm 리팩토링

### DIFF
--- a/APEX/APEX/Data/ClientsStore.swift
+++ b/APEX/APEX/Data/ClientsStore.swift
@@ -19,6 +19,20 @@ final class ClientsStore: ObservableObject {
     private var cancellables: Set<AnyCancellable> = []
 
     @Published var clients: [Client]
+    // Global CloudKit loading indicator state
+    @Published var isCloudSyncInProgress: Bool = false
+    private var activeSyncOperations: Int = 0
+    private func addSyncOperations(_ count: Int = 1) {
+        activeSyncOperations += max(0, count)
+        isCloudSyncInProgress = activeSyncOperations > 0
+    }
+    private func completeOneSyncOperation() {
+        if activeSyncOperations > 0 { activeSyncOperations -= 1 }
+        isCloudSyncInProgress = activeSyncOperations > 0
+    }
+    // Public helpers for other modules to toggle global loading UI
+    func beginCloudSync(_ count: Int = 1) { addSyncOperations(count) }
+    func endCloudSync() { completeOneSyncOperation() }
 
     private init() {
         if let fromAppGroup = localStore.loadClientsFromAppGroup() {
@@ -206,6 +220,7 @@ final class ClientsStore: ObservableObject {
         if UserDefaults.standard.bool(forKey: "apex.isGuestMode") {
             return
         }
+        addSyncOperations()
         let sort = NSSortDescriptor(key: "surname", ascending: true)
         CloudKitManager.shared.query(type: "Client", predicate: NSPredicate(value: true), sortDescriptors: [sort]) { [weak self] result in
             guard let self else { return }
@@ -346,12 +361,14 @@ final class ClientsStore: ObservableObject {
                     }
                 }
             }
+            self.completeOneSyncOperation()
         }
     }
 
     /// Pull current user's profile from Users record type and merge into index 0.
     private func pullUserFromCloudKit() {
         if UserDefaults.standard.bool(forKey: "apex.isGuestMode") { return }
+        addSyncOperations()
         CloudKitManager.shared.query(type: "AppUser") { [weak self] result in
             guard let self else { return }
             switch result {
@@ -428,6 +445,7 @@ final class ClientsStore: ObservableObject {
                     self.setUserRecordID(rec.recordID)
                 }
             }
+            self.completeOneSyncOperation()
         }
     }
 
@@ -701,6 +719,8 @@ final class ClientsStore: ObservableObject {
     private func pullAllClientNotesFromCloudKit() {
         if UserDefaults.standard.bool(forKey: "apex.isGuestMode") { return }
         let snapshot = clients
+        if snapshot.isEmpty { return }
+        addSyncOperations(snapshot.count)
         for client in snapshot {
             CloudKitNotesManager.shared.fetchNotes(for: client.id) { result in
                 if case .success(let fetched) = result {
@@ -723,6 +743,7 @@ final class ClientsStore: ObservableObject {
                         ChatStore.shared.setNotes(merged, for: client.id)
                     }
                 }
+                self.completeOneSyncOperation()
             }
         }
     }

--- a/APEX/APEX/Network/CloudKitManager.swift
+++ b/APEX/APEX/Network/CloudKitManager.swift
@@ -13,6 +13,43 @@ final class CloudKitManager {
     static let shared = CloudKitManager()
     private init() {}
 
+    // MARK: - Retry Policy
+    private let maxRetryAttempts = 3
+    private let baseRetryDelay: TimeInterval = 1.0
+    
+    private func retryDelay(for error: CKError, attempt: Int) -> TimeInterval? {
+        if let after = error.userInfo[CKErrorRetryAfterKey] as? TimeInterval {
+            return after
+        }
+        switch error.code {
+        case .networkUnavailable, .networkFailure, .serviceUnavailable, .requestRateLimited, .zoneBusy, .resultsTruncated, .serverRejectedRequest:
+            // Exponential backoff
+            return min(8.0, baseRetryDelay * pow(2.0, Double(attempt - 1)))
+        default:
+            return nil
+        }
+    }
+    
+    private func isRetryable(_ error: CKError) -> Bool {
+        switch error.code {
+        case .networkUnavailable, .networkFailure, .serviceUnavailable, .requestRateLimited, .zoneBusy, .resultsTruncated, .serverRejectedRequest, .limitExceeded:
+            return true
+        default:
+            return false
+        }
+    }
+    
+    // Central configuration for all operations
+    private func configure(_ operation: CKOperation) {
+        operation.qualityOfService = .userInitiated
+        if let cfg = operation.configuration {
+            cfg.allowsCellularAccess = true
+            cfg.timeoutIntervalForRequest = 30
+            cfg.timeoutIntervalForResource = 300
+            operation.configuration = cfg
+        }
+    }
+
     // MARK: - Container / Database
     // Use the default container declared in entitlements (iCloud.$(PRODUCT_BUNDLE_IDENTIFIER))
     // to avoid mismatches with hard-coded identifiers across schemes/configs.
@@ -30,11 +67,12 @@ final class CloudKitManager {
             let info = CKSubscription.NotificationInfo()
             info.shouldSendContentAvailable = true
             sub.notificationInfo = info
-            let op = CKModifySubscriptionsOperation(subscriptionsToSave: [sub], subscriptionIDsToDelete: [])
-            op.modifySubscriptionsCompletionBlock = { _, _, error in
+            let modifyOperation = CKModifySubscriptionsOperation(subscriptionsToSave: [sub], subscriptionIDsToDelete: [])
+            modifyOperation.modifySubscriptionsCompletionBlock = { _, _, error in
                 if let error { print("[CloudKit] ensureDatabaseSubscription error: \(error)") }
             }
-            self.privateDB.add(op)
+            self.configure(modifyOperation)
+            self.privateDB.add(modifyOperation)
         }
     }
 
@@ -61,27 +99,46 @@ final class CloudKitManager {
     }
 
     func fetchDatabaseChanges(completion: @escaping (UIBackgroundFetchResult) -> Void) {
-        let op = CKFetchDatabaseChangesOperation(previousServerChangeToken: privateDBChangeToken)
-        var hasChanges = false
-        op.recordZoneWithIDChangedBlock = { _ in hasChanges = true }
-        op.changeTokenUpdatedBlock = { [weak self] token in self?.privateDBChangeToken = token }
-        op.fetchDatabaseChangesCompletionBlock = { [weak self] token, moreComing, error in
-            if let error {
-                print("[CloudKit] fetchDatabaseChanges error: \(error)")
-                completion(.failed)
-                return
+        func run(attempt: Int) {
+            let fetchOperation = CKFetchDatabaseChangesOperation(previousServerChangeToken: privateDBChangeToken)
+            var hasChanges = false
+            fetchOperation.recordZoneWithIDChangedBlock = { _ in hasChanges = true }
+            fetchOperation.changeTokenUpdatedBlock = { [weak self] token in
+                self?.privateDBChangeToken = token
             }
-            if let token { self?.privateDBChangeToken = token }
-            if hasChanges || moreComing {
-                DispatchQueue.main.async {
-                    NotificationCenter.default.post(name: .cloudKitDatabaseDidChange, object: nil)
+            fetchOperation.fetchDatabaseChangesCompletionBlock = { [weak self] token, moreComing, error in
+                if let error {
+                    if let ck = error as? CKError {
+                        let shouldRetry = (attempt < (self?.maxRetryAttempts ?? 0)) && (self?.isRetryable(ck) == true)
+                        let delay = self?.retryDelay(for: ck, attempt: attempt + 1)
+                        if shouldRetry, let delay {
+                            DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
+                                run(attempt: attempt + 1)
+                            }
+                        } else {
+                            print("[CloudKit] fetchDatabaseChanges error: \(error)")
+                            completion(.failed)
+                        }
+                    } else {
+                        print("[CloudKit] fetchDatabaseChanges non-CKError: \(error)")
+                        completion(.failed)
+                    }
+                    return
                 }
-                completion(.newData)
-            } else {
-                completion(.noData)
+                if let token { self?.privateDBChangeToken = token }
+                if hasChanges || moreComing {
+                    DispatchQueue.main.async {
+                        NotificationCenter.default.post(name: .cloudKitDatabaseDidChange, object: nil)
+                    }
+                    completion(.newData)
+                } else {
+                    completion(.noData)
+                }
             }
+            configure(fetchOperation)
+            privateDB.add(fetchOperation)
         }
-        privateDB.add(op)
+        run(attempt: 1)
     }
 
     // MARK: - Assets
@@ -99,35 +156,84 @@ final class CloudKitManager {
 
     // MARK: - CRUD helpers
     func saveRecord(type: String, recordID: CKRecord.ID? = nil, fields: [String: CKRecordValueProtocol], completion: ((Result<CKRecord, Error>) -> Void)? = nil) {
-        let record = recordID.map { CKRecord(recordType: type, recordID: $0) } ?? CKRecord(recordType: type)
-        fields.forEach { record[$0.key] = $0.value }
-        privateDB.save(record) { rec, err in
-            if let err { completion?(.failure(err)) }
-            else if let rec { completion?(.success(rec)) }
+        func run(attempt: Int) {
+            let record = recordID.map { CKRecord(recordType: type, recordID: $0) } ?? CKRecord(recordType: type)
+            fields.forEach { record[$0.key] = $0.value }
+            privateDB.save(record) { rec, err in
+                if let err {
+                    if let ck = err as? CKError, attempt < self.maxRetryAttempts, self.isRetryable(ck), let delay = self.retryDelay(for: ck, attempt: attempt + 1) {
+                        DispatchQueue.global().asyncAfter(deadline: .now() + delay) { run(attempt: attempt + 1) }
+                    } else {
+                        completion?(.failure(err))
+                    }
+                } else if let rec {
+                    completion?(.success(rec))
+                }
+            }
         }
+        run(attempt: 1)
     }
 
     func query(type: String, predicate: NSPredicate = NSPredicate(value: true), sortDescriptors: [NSSortDescriptor]? = nil, resultsLimit: Int = CKQueryOperation.maximumResults, completion: @escaping (Result<[CKRecord], Error>) -> Void) {
-        let q = CKQuery(recordType: type, predicate: predicate)
-        q.sortDescriptors = sortDescriptors
-        let op = CKQueryOperation(query: q)
-        op.resultsLimit = resultsLimit
-        var results: [CKRecord] = []
-        op.recordMatchedBlock = { _, result in if case .success(let r) = result { results.append(r) } }
-        op.queryResultBlock = { result in
-            switch result {
-            case .success: completion(.success(results))
-            case .failure(let e): completion(.failure(e))
+        var collected: [CKRecord] = []
+        
+        func run(cursor: CKQueryOperation.Cursor?, attempt: Int) {
+            let queryOperation: CKQueryOperation
+            if let cursor {
+                queryOperation = CKQueryOperation(cursor: cursor)
+            } else {
+                let query = CKQuery(recordType: type, predicate: predicate)
+                query.sortDescriptors = sortDescriptors
+                queryOperation = CKQueryOperation(query: query)
+                queryOperation.resultsLimit = resultsLimit
             }
+            queryOperation.recordMatchedBlock = { _, result in
+                if case .success(let matchedRecord) = result {
+                    collected.append(matchedRecord)
+                }
+            }
+            queryOperation.queryResultBlock = { result in
+                switch result {
+                case .success(let nextCursor):
+                    if let next = nextCursor {
+                        run(cursor: next, attempt: 1)
+                    } else {
+                        completion(.success(collected))
+                    }
+                case .failure(let error):
+                    if let ck = error as? CKError,
+                       attempt < self.maxRetryAttempts,
+                       self.isRetryable(ck),
+                       let delay = self.retryDelay(for: ck, attempt: attempt + 1) {
+                        DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
+                            run(cursor: cursor, attempt: attempt + 1)
+                        }
+                    } else {
+                        completion(.failure(error))
+                    }
+                }
+            }
+            configure(queryOperation)
+            privateDB.add(queryOperation)
         }
-        privateDB.add(op)
+        run(cursor: nil, attempt: 1)
     }
 
     func deleteRecord(recordID: CKRecord.ID, completion: ((Result<CKRecord.ID, Error>) -> Void)? = nil) {
-        privateDB.delete(withRecordID: recordID) { id, err in
-            if let err { completion?(.failure(err)) }
-            else if let id { completion?(.success(id)) }
+        func run(attempt: Int) {
+            privateDB.delete(withRecordID: recordID) { id, err in
+                if let err {
+                    if let ck = err as? CKError, attempt < self.maxRetryAttempts, self.isRetryable(ck), let delay = self.retryDelay(for: ck, attempt: attempt + 1) {
+                        DispatchQueue.global().asyncAfter(deadline: .now() + delay) { run(attempt: attempt + 1) }
+                    } else {
+                        completion?(.failure(err))
+                    }
+                } else if let id {
+                    completion?(.success(id))
+                }
+            }
         }
+        run(attempt: 1)
     }
 
     /// Safely update an existing record by fetching it first, applying fields and clearing specified keys.
@@ -135,19 +241,36 @@ final class CloudKitManager {
                       fields: [String: CKRecordValueProtocol],
                       clearKeys: [String] = [],
                       completion: ((Result<CKRecord, Error>) -> Void)? = nil) {
-        privateDB.fetch(withRecordID: recordID) { [weak self] rec, err in
-            guard let self else { return }
-            if let err { completion?(.failure(err)); return }
-            guard let rec else {
-                completion?(.failure(NSError(domain: "CloudKit", code: -1, userInfo: [NSLocalizedDescriptionKey: "Record not found"]))); return
-            }
-            fields.forEach { rec[$0.key] = $0.value }
-            clearKeys.forEach { rec[$0] = nil }
-            self.privateDB.save(rec) { saved, err in
-                if let err { completion?(.failure(err)) }
-                else if let saved { completion?(.success(saved)) }
+        func fetchThenSave(attempt: Int) {
+            privateDB.fetch(withRecordID: recordID) { [weak self] rec, err in
+                guard let self else { return }
+                if let err {
+                    if let ck = err as? CKError, attempt < self.maxRetryAttempts, self.isRetryable(ck), let delay = self.retryDelay(for: ck, attempt: attempt + 1) {
+                        DispatchQueue.global().asyncAfter(deadline: .now() + delay) { fetchThenSave(attempt: attempt + 1) }
+                    } else {
+                        completion?(.failure(err))
+                    }
+                    return
+                }
+                guard let rec else {
+                    completion?(.failure(NSError(domain: "CloudKit", code: -1, userInfo: [NSLocalizedDescriptionKey: "Record not found"]))); return
+                }
+                fields.forEach { rec[$0.key] = $0.value }
+                clearKeys.forEach { rec[$0] = nil }
+                self.privateDB.save(rec) { saved, err in
+                    if let err {
+                        if let ck = err as? CKError, attempt < self.maxRetryAttempts, self.isRetryable(ck), let delay = self.retryDelay(for: ck, attempt: attempt + 1) {
+                            DispatchQueue.global().asyncAfter(deadline: .now() + delay) { fetchThenSave(attempt: attempt + 1) }
+                        } else {
+                            completion?(.failure(err))
+                        }
+                    } else if let saved {
+                        completion?(.success(saved))
+                    }
+                }
             }
         }
+        fetchThenSave(attempt: 1)
     }
 }
 

--- a/APEX/APEX/Presentation/Chatting/ChattingViewModel.swift
+++ b/APEX/APEX/Presentation/Chatting/ChattingViewModel.swift
@@ -180,6 +180,7 @@ private extension ChattingViewModel {
             ChatStore.shared.setNotes(seeded, for: clientId)
             // If nothing local, attempt a lightweight CloudKit pull to repopulate chat on cold start
             if SyncSettings.isAutoOn {
+                ClientsStore.shared.beginCloudSync()
                 CloudKitNotesManager.shared.fetchNotes(for: clientId) { [weak self] result in
                     guard let self else { return }
                     if case .success(let fetched) = result {
@@ -201,6 +202,7 @@ private extension ChattingViewModel {
                             ChatStore.shared.setNotes(sorted, for: self.clientId)
                         }
                     }
+                    ClientsStore.shared.endCloudSync()
                 }
             }
         } else {
@@ -618,6 +620,7 @@ private extension ChattingViewModel {
             .sink { [weak self] _ in
                 guard let self else { return }
                 guard SyncSettings.isAutoOn else { return }
+                ClientsStore.shared.beginCloudSync()
                 CloudKitNotesManager.shared.fetchNotes(for: self.clientId) { result in
                     if case .success(let fetched) = result {
                         DispatchQueue.main.async {
@@ -638,6 +641,7 @@ private extension ChattingViewModel {
                             ChatStore.shared.setNotes(sorted, for: self.clientId)
                         }
                     }
+                    ClientsStore.shared.endCloudSync()
                 }
             }
             .store(in: &cancellables)

--- a/APEX/APEX/Presentation/DataManagement/DataManagementServices.swift
+++ b/APEX/APEX/Presentation/DataManagement/DataManagementServices.swift
@@ -104,6 +104,11 @@ final class RealStorageSyncService: StorageSyncService {
         }
         // Pull latest notes from CloudKit and reflect into app immediately (even when auto-sync is off)
         // We update ChatStore only; ClientsStore will mirror via its NotificationCenter subscriber.
+        if !clients.isEmpty {
+            DispatchQueue.main.async {
+                ClientsStore.shared.beginCloudSync(clients.count)
+            }
+        }
         for client in clients {
             CloudKitNotesManager.shared.fetchNotes(for: client.id) { result in
                 if case .success(let fetched) = result {
@@ -122,6 +127,9 @@ final class RealStorageSyncService: StorageSyncService {
                         }
                         ChatStore.shared.setNotes(merged, for: client.id)
                     }
+                }
+                DispatchQueue.main.async {
+                    ClientsStore.shared.endCloudSync()
                 }
             }
         }

--- a/APEX/APEX/Presentation/Root/RootView.swift
+++ b/APEX/APEX/Presentation/Root/RootView.swift
@@ -11,6 +11,7 @@ struct RootView: View {
     enum Tabs { case contacts, notes, search }
     
     @EnvironmentObject private var router: NavigationRouter
+    @ObservedObject private var sync = ClientsStore.shared
     @State private var selection: Tabs = .contacts
     @State private var lastNonSearchSelection: Tabs = .contacts
     
@@ -46,6 +47,24 @@ struct RootView: View {
             }
         }
         .apexSwipeBack()
+        .overlay(alignment: .center) {
+            if sync.isCloudSyncInProgress {
+                ZStack {
+                    Color.black.opacity(0.2)
+                        .ignoresSafeArea()
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .tint(Color("Primary"))
+                        .scaleEffect(1.2)
+                        .padding(24)
+                        .background(
+                            RoundedRectangle(cornerRadius: 14)
+                                .fill(Color(.systemBackground))
+                                .shadow(color: Color.black.opacity(0.15), radius: 12, x: 0, y: 4)
+                        )
+                }
+            }
+        }
     }
 }
 

--- a/APEX/StashShare/ShareSheetView.swift
+++ b/APEX/StashShare/ShareSheetView.swift
@@ -10,16 +10,7 @@ import UniformTypeIdentifiers
 import AVFoundation
 
 struct ShareSheetView: View {
-    enum Tab: String, CaseIterable, Identifiable { case connects = "연결", recents = "최근"; var id: String { rawValue } }
-    
-    @State private var selectedTab: Tab = .connects
-    @State private var selectedIds: Set<UUID> = []
-    @State private var inputText: String = ""
-    @State private var attachments: [ShareAttachmentItem]
-    private let onFinished: (() -> Void)?
-    
-    @State private var clients: [PClient] = []
-    @State private var inputBarHeight: CGFloat = 0
+    @StateObject private var viewModel: ShareSheetViewModel
     
     private struct InputBarHeightKey: PreferenceKey {
         static var defaultValue: CGFloat = 0
@@ -27,52 +18,51 @@ struct ShareSheetView: View {
     }
     
     init(attachments: [ShareAttachmentItem], onFinished: (() -> Void)?) {
-        _attachments = State(initialValue: attachments)
-        self.onFinished = onFinished
+        _viewModel = StateObject(wrappedValue: ShareSheetViewModel(attachments: attachments, onFinished: onFinished))
     }
     
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                switch selectedTab {
+                switch viewModel.selectedTab {
                 case .connects:
-                    if !connectsFavorites.isEmpty {
-                        ForEach(connectsFavorites) { client in
+                    if !viewModel.connectsFavorites.isEmpty {
+                        ForEach(viewModel.connectsFavorites) { client in
                             ShareRowExt(
                                 client: client,
                                 mode: .contacts,
-                                isSelected: selectedIds.contains(client.id),
-                                onToggleSelect: { toggleSelect(client.id) }
+                                isSelected: viewModel.selectedIds.contains(client.id),
+                                onToggleSelect: { viewModel.send(.toggleSelect(client.id)) }
                             )
                         }
                     }
-                    ForEach(connectsCompanyKeys, id: \.self) { key in
+                    ForEach(viewModel.connectsCompanyKeys, id: \.self) { key in
                         Text(key).font(.body1).foregroundColor(.primary)
                             .padding(.top, 8)
-                        ForEach(connectsGrouped[key] ?? []) { client in
+                        ForEach(viewModel.connectsGrouped[key] ?? []) { client in
                             ShareRowExt(
                                 client: client,
                                 mode: .contacts,
-                                isSelected: selectedIds.contains(client.id),
-                                onToggleSelect: { toggleSelect(client.id) }
+                                isSelected: viewModel.selectedIds.contains(client.id),
+                                onToggleSelect: { viewModel.send(.toggleSelect(client.id)) }
                             )
                         }
                     }
                 case .recents:
-                    ForEach(recentsPinned) { client in
+                    ForEach(viewModel.recentsPinned) { client in
                         ShareRowExt(
                             client: client,
                             mode: .recents,
-                            isSelected: selectedIds.contains(client.id),
-                            onToggleSelect: { toggleSelect(client.id) }
+                            isSelected: viewModel.selectedIds.contains(client.id),
+                            onToggleSelect: { viewModel.send(.toggleSelect(client.id)) }
                         )
                     }
-                    ForEach(recentsUnpinned) { client in
+                    ForEach(viewModel.recentsUnpinned) { client in
                         ShareRowExt(
                             client: client,
                             mode: .recents,
-                            isSelected: selectedIds.contains(client.id),
-                            onToggleSelect: { toggleSelect(client.id) }
+                            isSelected: viewModel.selectedIds.contains(client.id),
+                            onToggleSelect: { viewModel.send(.toggleSelect(client.id)) }
                         )
                     }
                 }
@@ -83,32 +73,32 @@ struct ShareSheetView: View {
         // Tap-to-dismiss keyboard removed for app extension compatibility
         .overlay(alignment: .bottom) {
             VStack(spacing: 6) {
-                let visualItems: [ShareAttachmentItem] = attachments.filter { item in
+                let visualItems: [ShareAttachmentItem] = viewModel.attachments.filter { item in
                     switch item.kind { case .image, .video: return true; default: return false }
                 }
                 if !visualItems.isEmpty {
                     AttachBarExt(
                         items: visualItems,
-                        onRemove: { removeAttachment($0) }
+                        onRemove: { viewModel.send(.removeAttachment($0)) }
                     )
                 }
             }
-            .padding(.bottom, inputBarHeight + 8)
+            .padding(.bottom, viewModel.inputBarHeight + 8)
             .ignoresSafeArea(.keyboard, edges: .bottom)
         }
         .safeAreaInset(edge: .top) {
             VStack(spacing: 0) {
                 ShareTopBarExt(
                     title: "노트에 공유",
-                    selectedCount: selectedIds.count,
-                    onClose: { onFinished?() },
+                    selectedCount: viewModel.selectedIds.count,
+                    onClose: { viewModel.send(.close) },
                     onSearch: { }
                 )
                 .padding(.top, 16)
                 .background(ShareTheme.background)
                 
                 Group {
-                    if !selectedIds.isEmpty {
+                    if !viewModel.selectedIds.isEmpty {
                         selectedClientsBar
                             .padding(.vertical, 8)
                             .background(ShareTheme.background)
@@ -121,9 +111,9 @@ struct ShareSheetView: View {
         }
         .safeAreaInset(edge: .bottom) {
             ShareInputBarExt(
-                text: $inputText,
-                isEnabled: !selectedIds.isEmpty,
-                onSend: { send() }
+                text: $viewModel.inputText,
+                isEnabled: !viewModel.selectedIds.isEmpty,
+                onSend: { viewModel.send(.send) }
             )
             .background(
                 GeometryReader { proxy in
@@ -131,24 +121,14 @@ struct ShareSheetView: View {
                 }
             )
         }
-        .onPreferenceChange(InputBarHeightKey.self) { inputBarHeight = $0 }
-        .onAppear {
-            clients = LocalStoreExt.shared.loadClients()
-        }
+        .onPreferenceChange(InputBarHeightKey.self) { viewModel.send(.setInputBarHeight($0)) }
+        .onAppear { viewModel.send(.onAppear) }
     }
     
     private var selectedClientsBar: some View {
-        let selected: [PClient] = clients
-            .filter { selectedIds.contains($0.id) }
-            .sorted(by: { lhs, rhs in
-                let lhsName = "\(lhs.name) \(lhs.surname)"
-                let rhsName = "\(rhs.name) \(rhs.surname)"
-                return lhsName.localizedCaseInsensitiveCompare(rhsName) == .orderedAscending
-            })
-        
         return ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 12) {
-                ForEach(selected) { client in
+                ForEach(viewModel.selectedClientsSorted) { client in
                     chip(for: client)
                 }
             }
@@ -169,7 +149,7 @@ struct ShareSheetView: View {
                     textColor: .white,
                     fontWeight: .semibold
                 )
-                Button { toggleSelect(client.id) } label: {
+                Button { viewModel.send(.toggleSelect(client.id)) } label: {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 14, weight: .medium))
                         .foregroundColor(.black)
@@ -188,20 +168,20 @@ struct ShareSheetView: View {
     
     private var tabPicker: some View {
         HStack(spacing: 0) {
-            ForEach(Tab.allCases) { tab in
+            ForEach(ShareSheetViewModel.Tab.allCases) { tab in
                 Button {
                     withAnimation(.spring(response: 0.22, dampingFraction: 0.95)) {
-                        selectedTab = tab
+                        viewModel.send(.setTab(tab))
                     }
                 } label: {
                     VStack(spacing: 8) {
                         Text(tab.rawValue)
                             .font(.subheadline)
                             .fontWeight(.semibold)
-                            .foregroundColor(selectedTab == tab ? ShareTheme.primary : ShareTheme.backgroundHover)
+                            .foregroundColor(viewModel.selectedTab == tab ? ShareTheme.primary : ShareTheme.backgroundHover)
                         Rectangle()
-                            .fill(selectedTab == tab ? ShareTheme.primary : ShareTheme.backgroundHover)
-                            .frame(height: selectedTab == tab ? 4 : 2)
+                            .fill(viewModel.selectedTab == tab ? ShareTheme.primary : ShareTheme.backgroundHover)
+                            .frame(height: viewModel.selectedTab == tab ? 4 : 2)
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 8)
@@ -213,108 +193,6 @@ struct ShareSheetView: View {
         .frame(height: 40)
     }
     
-    private var connectsFavorites: [PClient] {
-        clients.filter { $0.favorite }
-            .sorted {
-                "\($0.name) \($0.surname)".localizedCaseInsensitiveCompare("\($1.name) \($1.surname)") == .orderedAscending
-            }
-    }
-    private var connectsGrouped: [String: [PClient]] {
-        let nonFavs = clients.filter { !$0.favorite }
-        let grouped = Dictionary(grouping: nonFavs, by: { $0.company })
-        var sorted: [String: [PClient]] = [:]
-        for key in grouped.keys.sorted(by: { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }) {
-            sorted[key] = grouped[key]!.sorted {
-                "\($0.name) \($0.surname)".localizedCaseInsensitiveCompare("\($1.name) \($1.surname)") == .orderedAscending
-            }
-        }
-        return sorted
-    }
-    private var connectsCompanyKeys: [String] { Array(connectsGrouped.keys).sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending } }
-    
-    private var recentsSorted: [PClient] {
-        clients.sorted {
-            let l = $0.notes.max(by: { $0.uploadedAt < $1.uploadedAt })?.uploadedAt ?? .distantPast
-            let r = $1.notes.max(by: { $0.uploadedAt < $1.uploadedAt })?.uploadedAt ?? .distantPast
-            return l > r
-        }
-    }
-    private var recentsPinned: [PClient] { recentsSorted.filter { $0.pin } }
-    private var recentsUnpinned: [PClient] { recentsSorted.filter { !$0.pin } }
-    
-    private func toggleSelect(_ id: UUID) {
-        if selectedIds.contains(id) { selectedIds.remove(id) } else { selectedIds.insert(id) }
-    }
-    
-    private func removeAttachment(_ item: ShareAttachmentItem) {
-        attachments.removeAll { $0.id == item.id }
-    }
-    
-    private func send() {
-        guard !selectedIds.isEmpty else { return }
-        
-        let typed = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let seeded = attachments.compactMap { item -> String? in
-            if case let .text(text) = item.kind { return text } else { return nil }
-        }.first?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        
-        let bundle = makePersistedBundle()
-        if bundle == nil && typed.isEmpty && seeded.isEmpty { return }
-        
-        var updated = clients
-        for idx in updated.indices {
-            guard selectedIds.contains(updated[idx].id) else { continue }
-            var notesToAppend: [PNote] = []
-            if let bundle {
-                notesToAppend.append(PNote(id: UUID(), uploadedAt: Date(), text: nil, bundle: bundle))
-            }
-            if !seeded.isEmpty {
-                notesToAppend.append(PNote(id: UUID(), uploadedAt: Date(), text: seeded, bundle: nil))
-            }
-            if !typed.isEmpty {
-                notesToAppend.append(PNote(id: UUID(), uploadedAt: Date(), text: typed, bundle: nil))
-            }
-            updated[idx].notes.append(contentsOf: notesToAppend)
-        }
-        clients = updated
-        LocalStoreExt.shared.saveClients(updated)
-        onFinished?()
-    }
-    
-    private func makePersistedBundle() -> PAttachmentBundle? {
-        var images: [PImageAttachment] = []
-        var videos: [PVideoAttachment] = []
-        var files: [PFileAttachment] = []
-        var audios: [PAudioAttachment] = []
-        
-        for (order, item) in attachments.enumerated() {
-            switch item.kind {
-            case .image(let uiImage):
-                if let data = uiImage.jpegData(compressionQuality: 0.9) {
-                    images.append(PImageAttachment(data: data, progress: nil, orderIndex: order))
-                }
-            case .video(let url, _):
-                if let url {
-                    let copied = ensureSharedCopy(of: url, directoryName: "SharedVideos", defaultExtension: "mov")
-                    videos.append(PVideoAttachment(url: copied.absoluteString, progress: nil, orderIndex: order))
-                }
-            case .file(let url):
-                let defaultExt = url.pathExtension.isEmpty ? "dat" : url.pathExtension
-                let copied = ensureSharedCopy(of: url, directoryName: "SharedFiles", defaultExtension: defaultExt)
-                files.append(PFileAttachment(url: copied.absoluteString, progress: nil))
-            case .audio(let url):
-                let defaultExt = url.pathExtension.isEmpty ? "m4a" : url.pathExtension
-                let copied = ensureSharedCopy(of: url, directoryName: "SharedAudios", defaultExtension: defaultExt)
-                audios.append(PAudioAttachment(url: copied.absoluteString, duration: assetDuration(for: copied)))
-            case .text:
-                break
-            }
-        }
-        if !images.isEmpty || !videos.isEmpty { return .media(images: images, videos: videos) }
-        if !files.isEmpty { return .files(files) }
-        if !audios.isEmpty { return .audio(audios) }
-        return nil
-    }
 }
  
 struct ShareTopBarExt: View {
@@ -567,36 +445,3 @@ struct ShareInputBarExt: View {
     
     private var computedIsEnabled: Bool { isEnabled }
 }
- 
-// MARK: - Utilities (copy into App Group + audio duration)
-private func ensureSharedCopy(of sourceURL: URL, directoryName: String, defaultExtension: String) -> URL {
-    let fileManager = FileManager.default
-    let baseDir = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.apex.StashShareExtension") ??
-        fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
-    let sharedDir = baseDir.appendingPathComponent(directoryName, isDirectory: true)
-    if !fileManager.fileExists(atPath: sharedDir.path) {
-        try? fileManager.createDirectory(at: sharedDir, withIntermediateDirectories: true)
-    }
-    let name = sourceURL.deletingPathExtension().lastPathComponent
-    let ext = sourceURL.pathExtension.isEmpty ? defaultExtension : sourceURL.pathExtension
-    var dest = sharedDir.appendingPathComponent(name).appendingPathExtension(ext)
-    var counter = 2
-    while fileManager.fileExists(atPath: dest.path) {
-        dest = sharedDir.appendingPathComponent("\(name) \(counter)").appendingPathExtension(ext)
-        counter += 1
-    }
-    if sourceURL != dest, !fileManager.fileExists(atPath: dest.path) {
-        try? fileManager.copyItem(at: sourceURL, to: dest)
-    }
-    return dest
-}
- 
-private func assetDuration(for url: URL) -> Double? {
-    let asset = AVAsset(url: url)
-    let seconds = asset.duration.seconds
-    return seconds.isFinite && seconds > 0 ? seconds : nil
-}
- 
- 
- 
-

--- a/APEX/StashShare/ShareSheetViewModel.swift
+++ b/APEX/StashShare/ShareSheetViewModel.swift
@@ -1,0 +1,228 @@
+//
+//  ShareSheetViewModel.swift
+//  StashShare
+//
+//  MVVM for ShareSheetView adopting the app's ViewModelable.
+//
+
+import Foundation
+import SwiftUI
+import Combine
+import AVFoundation
+
+@MainActor
+final class ShareSheetViewModel: ViewModelable {
+    enum Action {
+        case onAppear
+        case setTab(Tab)
+        case toggleSelect(UUID)
+        case removeAttachment(ShareAttachmentItem)
+        case setInputBarHeight(CGFloat)
+        case setText(String)
+        case send
+        case close
+    }
+    
+    enum Tab: String, CaseIterable, Identifiable {
+        case connects = "연결"
+        case recents = "최근"
+        var id: String { rawValue }
+    }
+    
+    // Inputs
+    @Published var selectedTab: Tab = .connects
+    @Published var selectedIds: Set<UUID> = []
+    @Published var inputText: String = ""
+    @Published var attachments: [ShareAttachmentItem]
+    @Published var inputBarHeight: CGFloat = 0
+    
+    // Data
+    @Published private(set) var clients: [PClient] = []
+    
+    // Outputs (computed)
+    var connectsFavorites: [PClient] {
+        clients
+            .filter { $0.favorite }
+            .sorted { "\($0.name) \($0.surname)".localizedCaseInsensitiveCompare("\($1.name) \($1.surname)") == .orderedAscending }
+    }
+    
+    var connectsGrouped: [String: [PClient]] {
+        let nonFavorites = clients.filter { !$0.favorite }
+        let grouped = Dictionary(grouping: nonFavorites, by: { $0.company })
+        var sorted: [String: [PClient]] = [:]
+        for key in grouped.keys.sorted(by: { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }) {
+            if let list = grouped[key] {
+                sorted[key] = list.sorted { "\($0.name) \($0.surname)".localizedCaseInsensitiveCompare("\($1.name) \($1.surname)") == .orderedAscending }
+            }
+        }
+        return sorted
+    }
+    
+    var connectsCompanyKeys: [String] {
+        Array(connectsGrouped.keys).sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+    
+    private var recentsSorted: [PClient] {
+        clients.sorted {
+            let l = $0.notes.max(by: { $0.uploadedAt < $1.uploadedAt })?.uploadedAt ?? .distantPast
+            let r = $1.notes.max(by: { $0.uploadedAt < $1.uploadedAt })?.uploadedAt ?? .distantPast
+            return l > r
+        }
+    }
+    var recentsPinned: [PClient] { recentsSorted.filter { $0.pin } }
+    var recentsUnpinned: [PClient] { recentsSorted.filter { !$0.pin } }
+    
+    var selectedClientsSorted: [PClient] {
+        clients
+            .filter { selectedIds.contains($0.id) }
+            .sorted {
+                let lhsName = "\($0.name) \($0.surname)"
+                let rhsName = "\($1.name) \($1.surname)"
+                return lhsName.localizedCaseInsensitiveCompare(rhsName) == .orderedAscending
+            }
+    }
+    
+    // Lifecycle / Callbacks
+    var onFinished: (() -> Void)?
+    
+    init(attachments: [ShareAttachmentItem], onFinished: (() -> Void)?) {
+        self.attachments = attachments
+        self.onFinished = onFinished
+    }
+    
+    func send(_ action: Action) {
+        switch action {
+        case .onAppear:
+            loadClients()
+        case .setTab(let tab):
+            selectedTab = tab
+        case .toggleSelect(let id):
+            toggleSelect(id)
+        case .removeAttachment(let item):
+            removeAttachment(item)
+        case .setInputBarHeight(let height):
+            inputBarHeight = height
+        case .setText(let text):
+            inputText = text
+        case .send:
+            sendNow()
+        case .close:
+            onFinished?()
+        }
+    }
+}
+
+// MARK: - Private helpers
+private extension ShareSheetViewModel {
+    func loadClients() {
+        clients = LocalStoreExt.shared.loadClients()
+    }
+    
+    func toggleSelect(_ id: UUID) {
+        if selectedIds.contains(id) {
+            selectedIds.remove(id)
+        } else {
+            selectedIds.insert(id)
+        }
+    }
+    
+    func removeAttachment(_ item: ShareAttachmentItem) {
+        attachments.removeAll { $0.id == item.id }
+    }
+    
+    func sendNow() {
+        guard !selectedIds.isEmpty else { return }
+        
+        let typed = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let seeded = attachments.compactMap { item -> String? in
+            if case let .text(text) = item.kind { return text } else { return nil }
+        }.first?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        
+        let bundle = makePersistedBundle()
+        if bundle == nil && typed.isEmpty && seeded.isEmpty { return }
+        
+        var updated = clients
+        for idx in updated.indices {
+            guard selectedIds.contains(updated[idx].id) else { continue }
+            var notesToAppend: [PNote] = []
+            if let bundle {
+                notesToAppend.append(PNote(id: UUID(), uploadedAt: Date(), text: nil, bundle: bundle))
+            }
+            if !seeded.isEmpty {
+                notesToAppend.append(PNote(id: UUID(), uploadedAt: Date(), text: seeded, bundle: nil))
+            }
+            if !typed.isEmpty {
+                notesToAppend.append(PNote(id: UUID(), uploadedAt: Date(), text: typed, bundle: nil))
+            }
+            updated[idx].notes.append(contentsOf: notesToAppend)
+        }
+        clients = updated
+        LocalStoreExt.shared.saveClients(updated)
+        onFinished?()
+    }
+    
+    func makePersistedBundle() -> PAttachmentBundle? {
+        var images: [PImageAttachment] = []
+        var videos: [PVideoAttachment] = []
+        var files: [PFileAttachment] = []
+        var audios: [PAudioAttachment] = []
+        
+        for (order, item) in attachments.enumerated() {
+            switch item.kind {
+            case .image(let uiImage):
+                if let data = uiImage.jpegData(compressionQuality: 0.9) {
+                    images.append(PImageAttachment(data: data, progress: nil, orderIndex: order))
+                }
+            case .video(let url, _):
+                if let url {
+                    let copied = ensureSharedCopy(of: url, directoryName: "SharedVideos", defaultExtension: "mov")
+                    videos.append(PVideoAttachment(url: copied.absoluteString, progress: nil, orderIndex: order))
+                }
+            case .file(let url):
+                let defaultExt = url.pathExtension.isEmpty ? "dat" : url.pathExtension
+                let copied = ensureSharedCopy(of: url, directoryName: "SharedFiles", defaultExtension: defaultExt)
+                files.append(PFileAttachment(url: copied.absoluteString, progress: nil))
+            case .audio(let url):
+                let defaultExt = url.pathExtension.isEmpty ? "m4a" : url.pathExtension
+                let copied = ensureSharedCopy(of: url, directoryName: "SharedAudios", defaultExtension: defaultExt)
+                audios.append(PAudioAttachment(url: copied.absoluteString, duration: assetDuration(for: copied)))
+            case .text:
+                break
+            }
+        }
+        if !images.isEmpty || !videos.isEmpty { return .media(images: images, videos: videos) }
+        if !files.isEmpty { return .files(files) }
+        if !audios.isEmpty { return .audio(audios) }
+        return nil
+    }
+    
+    func ensureSharedCopy(of sourceURL: URL, directoryName: String, defaultExtension: String) -> URL {
+        let fileManager = FileManager.default
+        let baseDir = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.apex.StashShareExtension") ??
+            fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let sharedDir = baseDir.appendingPathComponent(directoryName, isDirectory: true)
+        if !fileManager.fileExists(atPath: sharedDir.path) {
+            try? fileManager.createDirectory(at: sharedDir, withIntermediateDirectories: true)
+        }
+        let name = sourceURL.deletingPathExtension().lastPathComponent
+        let ext = sourceURL.pathExtension.isEmpty ? defaultExtension : sourceURL.pathExtension
+        var dest = sharedDir.appendingPathComponent(name).appendingPathExtension(ext)
+        var counter = 2
+        while fileManager.fileExists(atPath: dest.path) {
+            dest = sharedDir.appendingPathComponent("\(name) \(counter)").appendingPathExtension(ext)
+            counter += 1
+        }
+        if sourceURL != dest, !fileManager.fileExists(atPath: dest.path) {
+            try? fileManager.copyItem(at: sourceURL, to: dest)
+        }
+        return dest
+    }
+    
+    func assetDuration(for url: URL) -> Double? {
+        let asset = AVAsset(url: url)
+        let seconds = asset.duration.seconds
+        return seconds.isFinite && seconds > 0 ? seconds : nil
+    }
+}
+
+

--- a/APEX/StashShare/ViewModelable.swift
+++ b/APEX/StashShare/ViewModelable.swift
@@ -1,0 +1,18 @@
+//
+//  ViewModelable.swift
+//  StashShare
+//
+//  Duplicated protocol for the Share Extension target.
+//
+
+import Foundation
+import Combine
+
+@MainActor
+protocol ViewModelable: ObservableObject {
+    associatedtype Action
+    
+    func send(_ action: Action)
+}
+
+


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #이슈번호

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 클라우드킷 안정
- 공유확장 뷰 mvvm 리팩토링

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15, iOS 17.4 환경에서 정상 동작
- [ ] 다크모드 테스트는 이후 이슈로 분리 예정 (#000)

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- UI 컴포넌트 위치가 디자이너 시안과 다를 수 있어요 → 후속 PR에서 반영 예정
- API 에러 대응 로직은 공통 모듈화하는 작업과 함께 처리할 예정입니다

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- `XxxViewModel.swift` 파일의 로직 분리 구조
- `NetworkManager.swift`의 공통 로직 처리 방식